### PR TITLE
have the projects list be called on client side for article page

### DIFF
--- a/src/router/index.js
+++ b/src/router/index.js
@@ -18,8 +18,14 @@ export default new Router({
     routes: [
         { path: '/author/:authorId/:authorName?', component: List },
         { path: '/category/:title', component: List },
-        { path: '/story/:slug', component: Article },
-        { path: '/story/:slug/index.html', component: Article },
+        {
+            path: '/story/:slug',
+            component: Article,
+            children: [{
+                path: 'index.html',
+                component: Article
+            }]
+        },
         { path: '/q/:questionnaireId/:resultId?', component: Questionnaire },
         { path: '/search/:keyword', component: Search },
         { path: '/section/:title', component: List },

--- a/src/store/api.js
+++ b/src/store/api.js
@@ -108,7 +108,16 @@ function loadCommonData(endpoints = []) {
     let mapped = _.map(endpoints, (n) => { return 'endpoint=' + n })
     let combo_params = mapped.join('&')
     const { LOCAL_PROTOCOL, LOCAL_PORT, LOCAL_HOST } = config
-    let url = `${_host}/api/combo?endpoint=sections&endpoint=topics&endpoint=projects&`
+    let url = `${_host}/api/combo?endpoint=sections&endpoint=topics&`
+    url = url + combo_params
+    return _doFetch(url)
+}
+
+function loadDataByCombo(endpoints = []) {
+    let mapped = _.map(endpoints, (n) => { return 'endpoint=' + n })
+    let combo_params = mapped.join('&')
+    const { LOCAL_PROTOCOL, LOCAL_PORT, LOCAL_HOST } = config
+    let url = `${_host}/api/combo?`
     url = url + combo_params
     return _doFetch(url)
 }
@@ -223,6 +232,24 @@ export function fetchCommonData(endpoints = []) {
                 }
             })
             return commonData
+        })
+}
+
+export function fetchDataByCombo(endpoints = []) {
+    return Promise.all([loadDataByCombo(endpoints)])
+        .then((data) => {
+            let _data = {}
+            _.map(Object.keys(_.get(data[0], ['endpoints'])), (e) => {
+                _data[e] = _.get(data[0], ['endpoints', e])
+                if (e == 'sections') {
+                    _.forEach(_.get(data[0], ['endpoints', e, 'items']), (s) => {
+                        _.forEach(s.categories, (c) => {
+                            _.set(_data, ['categories', c.name], c)
+                        })
+                    })
+                }
+            })
+            return _data
         })
 }
 

--- a/src/views/Home.vue
+++ b/src/views/Home.vue
@@ -38,7 +38,7 @@ const MAXRESULT = 20
 const PAGE = 1
 
 const fetchCommonData = (store) => {
-  return store.dispatch('FETCH_COMMONDATA', { 'endpoints': [ 'posts-vue', 'choices' ] } ).then(() => {
+  return store.dispatch('FETCH_COMMONDATA', { 'endpoints': [ 'posts-vue', 'choices', 'projects' ] } ).then(() => {
     return store.dispatch('FETCH_EVENT', {
       params: {
         'max_results': 1,
@@ -137,7 +137,9 @@ export default {
     },
     handleScroll () {
       window.onscroll = (e) => {
-        let firstPageArticleHeight = document.getElementById('latestArticle').offsetHeight
+        const _latestArticleDiv = document.querySelector('#latestArticle')
+        if(!_latestArticleDiv) { return }
+        let firstPageArticleHeight = _latestArticleDiv.offsetHeight
         let firstPageArticleBottom = elmYPosition('#latestArticle') + ( firstPageArticleHeight )
         let currentBottom = currentYPosition() + window.innerHeight
         if ( ( currentBottom > firstPageArticleBottom ) && !this.hasScrollLoadMore) {

--- a/src/views/List.vue
+++ b/src/views/List.vue
@@ -338,7 +338,6 @@ export default {
   beforeRouteEnter (to, from, next) {
     let type = _.toUpper( _.split( to.path, '/' )[1] )
     next(vm => {
-      console.log('run here')
       let sectionStyle = _.get( _.find( _.get(vm.$store.state.commonData, ['sections', 'items']), 
         { 'name': _.get(to, ['params', 'title']) } ), ['style'] )
       fetchCommonData(vm.$store).then(() => {


### PR DESCRIPTION
fixed the issue if there's no article data

revise the route for /story/:slug/index.html

fixed the issue that if the dom #latestArticle can't not be found

have the latest articles related to the current article and poplist  be called on client side

have the projects list be called on client side for article page