### PR TITLE
udpate store test (_buildQuery, _doFetch)

### DIFF
--- a/.babelrc
+++ b/.babelrc
@@ -2,6 +2,7 @@
   "presets": ["@babel/preset-env"],
   "plugins": [
     "@babel/plugin-syntax-dynamic-import",
-    "@babel/transform-runtime"
+    "@babel/transform-runtime",
+    "babel-plugin-rewire"
   ]
 }

--- a/package-lock.json
+++ b/package-lock.json
@@ -2319,6 +2319,12 @@
       "integrity": "sha1-5h+uBaHKiAGq3uV6bWa4zvr0QWc=",
       "dev": true
     },
+    "babel-plugin-rewire": {
+      "version": "1.2.0",
+      "resolved": "https://registry.npmjs.org/babel-plugin-rewire/-/babel-plugin-rewire-1.2.0.tgz",
+      "integrity": "sha512-JBZxczHw3tScS+djy6JPLMjblchGhLI89ep15H3SyjujIzlxo5nr6Yjo7AXotdeVczeBmWs0tF8PgJWDdgzAkQ==",
+      "dev": true
+    },
     "babel-plugin-syntax-object-rest-spread": {
       "version": "6.13.0",
       "resolved": "http://registry.npmjs.org/babel-plugin-syntax-object-rest-spread/-/babel-plugin-syntax-object-rest-spread-6.13.0.tgz",

--- a/package.json
+++ b/package.json
@@ -13,7 +13,7 @@
     "e2e": "node test/e2e/runner.js",
     "lint": "eslint --ext .js,.vue src --color",
     "npm-forever": "forever -o out.log -e err.log -c 'node --expose-gc' serverCluster.js",
-    "test": "jest tests/unit/util/comm.test.js",
+    "test": "jest tests/unit/store/api.test.js",
     "unit": "cross-env BABEL_ENV=test karma start test/unit/karma.conf.js --single-run",
     "unit-watch": "cross-env BABEL_ENV=test karma start test/unit/karma.conf.js",
     "validate": "npm ls"
@@ -101,6 +101,7 @@
     "babel-eslint": "^10.0.1",
     "babel-jest": "^23.6.0",
     "babel-loader": "^8.0.4",
+    "babel-plugin-rewire": "^1.2.0",
     "chokidar": "^2.0.4",
     "eslint": "^5.8.0",
     "eslint-plugin-jest": "^22.0.0",

--- a/src/store/api.js
+++ b/src/store/api.js
@@ -26,19 +26,10 @@ function _buildQuery (params = {}) {
   return query
 }
 
-function _doFetch (url) {
-  return new Promise((resolve, reject) => {
-    superagent
+async function _doFetch (url) {
+  return await superagent
     .get(url)
-    // .query('')
-    .end(function (err, res) {
-      if (err) {
-        reject(err)
-      } else {
-        resolve(camelizeKeys(res.body))
-      }
-    })
-  })
+    .then(res => camelizeKeys(res.body))
 }
 
 function _logClient (params = {}) {

--- a/tests/unit/store/api.test.js
+++ b/tests/unit/store/api.test.js
@@ -1,0 +1,35 @@
+import api from '../../../src/store/api.js'
+import qs from 'qs'
+
+describe('_buildQuery', () => {
+  const _buildQuery = api.__get__('_buildQuery')
+  
+  const params1 = { max_results: 10, page: 1, sort: '-publishedDate' }
+  const params2 = { where: { isFeatured: true, eventType: 'embedded' }, max_results: 1 }
+  const params2Stringify = qs.stringify({ where: '{"isFeatured":true,"eventType":"embedded"}', max_results: 1 })
+  const params3 = { id: [ 2 ] }
+  const params4 = { id: [ 2, 3 ] }
+  const params4Stringify = qs.stringify({ id: '2,3' })
+  const params5 = { page: 1, game: '還願' }
+
+  test('build query', () => {
+    expect(_buildQuery(params1)).toEqual('max_results=10&page=1&sort=-publishedDate')
+    expect(_buildQuery(params2)).toEqual(params2Stringify)
+    expect(_buildQuery(params3)).toEqual('id=2')
+    expect(_buildQuery(params4)).toEqual(params4Stringify)
+    expect(_buildQuery(params5)).toEqual('page=1')
+  })
+})
+
+describe('_doFetch', () => {
+  const _doFetch = api.__get__('_doFetch')
+  
+  const url1 = 'https://www.mirrormedia.mg/api/combo?endpoint=posts-vue&endpoint=projects&endpoint=topics'
+  const url2 = 'https://www.mirrormedia.mg/api/posts?where={"slug":{"$in":["20190227edi004"]}}&clean=content'
+  const urlEmpty = 'http://www.mirrormedia.mg/api/notExist'
+  test('GET API data', async () => {
+    await expect(_doFetch(url1)).toResolve()
+    await expect(_doFetch(url2)).toResolve()
+    await expect(_doFetch(urlEmpty)).toReject()
+  })
+})


### PR DESCRIPTION
- add store api `_buildQuery` and `_doFetch` unit test
- add `babel-plugin-rewire` package for test internal function
- update `_doFetch` to use async/await