### PR TITLE
feat: 移除 FB comments plugin

### DIFF
--- a/src/components/article/ArticleBodyExternal.vue
+++ b/src/components/article/ArticleBodyExternal.vue
@@ -110,7 +110,6 @@
             <slot name="recommendList" />
             <slot name="popularList" />
             <slot name="projectList" />
-            <slot name="fbComment" />
           </section>
           <section class="article__aside">
             <slot name="dfp-PCR1" />
@@ -291,9 +290,6 @@ export default {
           padding 0
           font-size 0
           border none
-
-      .fbComment
-        margin 1.5em 0
 
       h3
         font-size 26px

--- a/src/components/article/ArticleBodyPhotography.vue
+++ b/src/components/article/ArticleBodyPhotography.vue
@@ -151,13 +151,6 @@ export default {
       type: Object,
       default: () => ({})
     },
-    initFBComment: {
-      default: () => {
-        return () => {
-          console.log('init fb comment')
-        }
-      }
-    },
     isApp: {
       type: Boolean,
       default: false

--- a/src/components/article/ArticleBodyPhotographyForApp.vue
+++ b/src/components/article/ArticleBodyPhotographyForApp.vue
@@ -117,13 +117,6 @@ export default {
     viewport: {
       type: Object,
       default: () => ({})
-    },
-    initFBComment: {
-      default: () => {
-        return () => {
-          console.log('init fb comment')
-        }
-      }
     }
   },
   data () {
@@ -269,7 +262,6 @@ export default {
           this.updateProgressbar(((this.currIndex - 1) * 100) / this.imgArr.length)
           if (this.currIndex === this.imgArr.length + 1) {
             this.creditCommentShow = true
-            this.initFBComment()
             removeClass(document.body, 'limited-height')
             removeClass(document.documentElement, 'limited-height')
             setTimeout(() => {

--- a/src/components/video/SingleVideoBody.vue
+++ b/src/components/video/SingleVideoBody.vue
@@ -18,15 +18,6 @@
         <slot name="share" />
       </div>
       <p v-text="video.description" />
-      <div class="single-video__comments">
-        <div
-          v-if="mounted"
-          :href="`${SITE_URL}/video/${video.id}`"
-          class="fb-comments"
-          data-numposts="5"
-          data-width="100%"
-        />
-      </div>
     </div>
     <template v-if="latest.length > 0">
       <div class="single-video__latest">
@@ -175,11 +166,6 @@ export default {
         font-size .875rem
         text-align justify
         line-height 1.43
-  &__comments
-    width 90%
-    margin 40px auto 0
-    >>> iframe
-      width 100% !important
 
 @media (min-width: 768px)
   .single-video
@@ -188,7 +174,7 @@ export default {
         width 60%
       h1
         font-size 1.375rem
-    &__video-info, &__latest, &__comments
+    &__video-info, &__latest
       width 60%
     &__latest
       h3
@@ -234,6 +220,4 @@ export default {
           font-size .875rem
           &:hover
             color #064f77
-    &__comments
-      width 100%
 </style>

--- a/src/views/Article.vue
+++ b/src/views/Article.vue
@@ -258,12 +258,6 @@
               :recommends="recommendlist"
               :excluding-article="routeUpateReferrerSlug"
             />
-            <div
-              slot="slot_fb_comment"
-              class="article_fb_comment"
-              style="margin: 1.5em 0;"
-              v-html="fbCommentDiv"
-            />
             <!-- dable -->
             <template
               v-if="!hiddenAdvertised"
@@ -318,13 +312,7 @@
         <ArticleBodyPhotography
           :article-data="articleData"
           :viewport="viewportWidth"
-          :init-f-b-comment="initializeFBComments"
         >
-          <div
-            slot="slot_fb_comment"
-            class="article_fb_comment"
-            v-html="fbCommentDiv"
-          />
           <ClientOnly>
             <div
               v-if="!hiddenAdvertised"
@@ -431,7 +419,6 @@ import {
 } from 'lodash'
 import { DFP_ID, DFP_SIZE_MAPPING, DFP_UNITS, DFP_OPTIONS, SECTION_WATCH_ID, SITE_MOBILE_URL, SITE_DESCRIPTION, SITE_TITLE, SITE_TITLE_SHORT, SITE_URL, SITE_OGIMAGE } from '../constants'
 
-import { ScrollTriggerRegister } from '../util/scrollTriggerRegister'
 import { adtracker } from 'src/util/adtracking'
 import { currEnv, getImage, lockJS, sendAdCoverGA, sendGaClickEvent, unLockJS, updateCookie } from '../util/comm'
 import { getRole } from '../util/mmABRoleAssign'
@@ -896,12 +883,6 @@ export default {
     eventEmbedded () {
       return _get(this.$store, 'state.eventEmbedded.items.0')
     },
-    fbAppId () {
-      return _get(this.$store, 'state.fbAppId')
-    },
-    fbCommentDiv () {
-      return `<div class="fb-comments" data-href="${this.articleUrl}" data-numposts="5" data-width="100%" data-order-by="reverse_time"></div>`
-    },
     hasDfpFixed () {
       return this.sectionId === SECTION_WATCH_ID
     },
@@ -984,7 +965,6 @@ export default {
   },
   watch: {
     '$route.fullPath': function () {
-      this.initializeFBComments()
       this.updateMediafarmersScript()
       this.checkLockJS()
       this.sendGA(this.articleData)
@@ -1020,10 +1000,6 @@ export default {
     this.checkLockJS()
     this.updateSysStage()
     this.abIndicator = this.getMmid()
-    const scrollTriggerRegister = new ScrollTriggerRegister([
-      { target: '.dable-widget', offset: 400, cb: this.initializeFBComments }
-    ])
-    scrollTriggerRegister.init()
 
     if (!_isEmpty(this.articleData)) {
       this.sendGA(this.articleData)
@@ -1097,16 +1073,6 @@ export default {
           sort: '-publishedDate',
           where: { sections: this.sectionId }
         })
-      }
-    },
-    initializeFBComments () {
-      if (window.FB) {
-        window.FB.init({
-          appId: this.fbAppId,
-          xfbml: true,
-          version: 'v2.0'
-        })
-        window.FB.XFBML.parse()
       }
     },
     insertMediafarmersScript () {

--- a/src/views/ArticleM.vue
+++ b/src/views/ArticleM.vue
@@ -130,12 +130,6 @@
               :recommends="recommendlist"
               :excluding-article="routeUpateReferrerSlug"
             />
-            <div
-              slot="slot_fb_comment"
-              class="article_fb_comment"
-              style="margin: 1.5em 0;"
-              v-html="fbCommentDiv"
-            />
             <template slot="recommendList">
               <div
                 id="dablewidget_GlYwenoy"
@@ -159,14 +153,8 @@
         <article-body-photography
           :article-data="articleData"
           :viewport="viewport"
-          :init-f-b-comment="initializeFBComments"
           :is-app="true"
         >
-          <div
-            slot="slot_fb_comment"
-            class="article_fb_comment"
-            v-html="fbCommentDiv"
-          />
           <div slot="slot_dfpFT">
             <vue-dfp
               :is="props.vueDfp"
@@ -246,7 +234,6 @@ import {
 } from 'lodash'
 import { DFP_ID, DFP_SIZE_MAPPING, DFP_UNITS, DFP_OPTIONS, SECTION_MAP, SECTION_WATCH_ID, SITE_OGIMAGE, SITE_TITLE_SHORT, SITE_URL } from '../constants'
 
-import { ScrollTriggerRegister } from '../util/scrollTriggerRegister'
 import { currEnv, lockJS, unLockJS, insertMicroAd, sendAdCoverGA, updateCookie } from '../util/comm'
 import { getRole } from '../util/mmABRoleAssign'
 import { microAds } from '../constants/microAds'
@@ -583,9 +570,6 @@ export default {
     fbAppId () {
       return _get(this.$store, ['state', 'fbAppId'])
     },
-    fbCommentDiv () {
-      return `<div class="fb-comments" data-href="${this.articleUrl}" data-numposts="5" data-width="100%" data-order-by="reverse_time"></div>`
-    },
     hasDfpFixed () {
       return this.sectionId === SECTION_WATCH_ID
     },
@@ -707,7 +691,6 @@ export default {
     fetchEvent(this.$store, 'logo')
   },
   mounted () {
-    this.initializeFBComments()
     this.insertMediafarmersScript()
     this.updateViewport()
     this.clientSideFlag = process.env.VUE_ENV === 'client'
@@ -718,11 +701,6 @@ export default {
     this.updateSysStage()
     // this.abIndicator = this.getMmid()
     this.sendGA(this.articleData)
-
-    const scrollTriggerRegister = new ScrollTriggerRegister([
-      { target: '.dable-widget', offset: 400, cb: this.initializeFBComments }
-    ])
-    scrollTriggerRegister.init()
   },
   updated () {
     this.updateSysStage()
@@ -750,16 +728,6 @@ export default {
     },
     getValue (o = {}, p = [], d = '') {
       return _get(o, p, d)
-    },
-    initializeFBComments () {
-      if (window.FB) {
-        window.FB && window.FB.init({
-          appId: this.fbAppId,
-          xfbml: true,
-          version: 'v2.0'
-        })
-        window.FB && window.FB.XFBML.parse()
-      }
     },
     insertMediafarmersScript () {
       const mediafarmersScript = document.createElement('script')

--- a/src/views/External.vue
+++ b/src/views/External.vue
@@ -126,12 +126,6 @@
           :viewport="viewport"
         />
         <div
-          slot="fbComment"
-          class="fbComment"
-        >
-          {{ fbCommentHtml }}
-        </div>
-        <div
           slot="footer"
           class="footer"
         >
@@ -262,7 +256,6 @@
 <script>
 import { DFP_ID, DFP_SIZE_MAPPING, DFP_UNITS, DFP_OPTIONS, SITE_MOBILE_URL, SITE_DESCRIPTION, SITE_OGIMAGE, SITE_TITLE_SHORT, SITE_URL } from '../constants'
 
-import { ScrollTriggerRegister } from '../util/scrollTriggerRegister'
 import { adtracker } from 'src/util/adtracking'
 import { consoleLogOnDev, currEnv, getValue, sendAdCoverGA, updateCookie } from '../util/comm'
 import { getRole } from '../util/mmABRoleAssign'
@@ -534,9 +527,6 @@ export default {
     fbAppId () {
       return _.get(this.$store, ['state', 'fbAppId'])
     },
-    fbCommentHtml () {
-      return `<div class="fb-comments" data-href="${SITE_URL}/external/${this.currArticleSlug}/" data-numposts="5" data-width="100%" data-order-by="reverse_time"></div>`
-    },
     // hasEventEmbedded () {
     //   const _now = moment()
     //   const _eventStartTime = moment(new Date(_.get(this.eventEmbedded, [ 'startDate' ])))
@@ -598,10 +588,6 @@ export default {
       this.$_external_sendGA(this.articleData)
       this.hasSentFirstEnterGA = true
     }
-    const scrollTriggerRegister = new ScrollTriggerRegister([
-      { target: '.dable-widget', offset: 400, cb: this.$_external_initializeFBComments }
-    ])
-    scrollTriggerRegister.init()
 
     window.addEventListener('resize', () => {
       this.$_external_updateViewport()
@@ -633,16 +619,6 @@ export default {
           { id: 'B', weight: 50 }]
       })
       return assisgnedRole || role
-    },
-    $_external_initializeFBComments () {
-      if (window.FB) {
-        window.FB && window.FB.init({
-          appId: this.fbAppId,
-          xfbml: true,
-          version: 'v2.0'
-        })
-        window.FB && window.FB.XFBML.parse()
-      }
     },
     $_external_insertMediafarmersScript () {
       const mediafarmersScript = document.createElement('script')
@@ -679,11 +655,6 @@ export default {
 </script>
 
 <style lang="stylus" scoped>
-
-.fbComment
-  >>> iframe
-    min-width 100%
-
 .dfp
   margin 20px auto
   text-align center

--- a/src/views/Topic.vue
+++ b/src/views/Topic.vue
@@ -71,11 +71,6 @@
               :viewport="viewport"
             />
           </div>
-          <div
-            slot="slot_fb_comment"
-            class="topicTimeline__fbComment"
-            v-html="fbCommentDiv"
-          />
         </template>
 
         <template v-else-if="topicType === 'portraitWall'">
@@ -596,9 +591,6 @@ export default {
     eventLogo () {
       return _.get(this.$store.state.eventLogo, ['items', '0'])
     },
-    fbCommentDiv () {
-      return `<div class="fb-comments" data-href="${this.articleUrl}" data-numposts="5" data-width="100%" data-order-by="reverse_time"></div>`
-    },
     fbAppId () {
       return _.get(this.$store, ['state', 'fbAppId'])
     },
@@ -1002,10 +994,6 @@ export default {
       color #fff
       text-align center
       font-weight 200
-  &__fbComment
-    width 100%
-    padding 0 5%
-    background-color #fff
 
 @media (min-width: 600px)
   .topic-view.wide


### PR DESCRIPTION
需求：
FB comments 已沒有跟粉專貼文同步，故希望移除以增進網站速度，並留一個版位以供日後使用。

調整項目：
移除與 fb comments 相關的程式碼。