### PR TITLE
fix: 修改 lightbox-img 區塊大於實際圖片區塊的問題

### DIFF
--- a/src/components/article/ArticleImg.vue
+++ b/src/components/article/ArticleImg.vue
@@ -171,8 +171,6 @@ export default {
       max-height 90vh
       max-width 90vw
       z-index 100002
-      object-fit contain
-      object-position center
       cursor default
       &.loading
         height 20%
@@ -195,7 +193,7 @@ export default {
     clear both
     margin 1.5em 0
 
-    & >>> img
+    & >>> img:not(.lightbox-img)
       width 100%
 
     .thumbnail


### PR DESCRIPTION
**問題：**
`.lightbox-img` 區塊大於實際圖片區塊，導致點擊實際圖片區塊外面時，無法關閉 `.lightbox`。

**原因：**
`.lightbox-img` 使用 `object-fit: contain;`，導致在某些狀況下，`.lightbox-img` 區塊會大於實際圖片區塊。
猜測當初會這麼做，是因為 `.content-image` 將底下的 `img` 都設為 `width: 100%;`，
導致 `.lightbox-img` 若不使用 `object-fit`，圖片就會無法等比例縮放。

**修改方式：**
原本 `.lightbox-img` 的 `max-height`、`max-width` 設定便能很良好地使圖片等比例縮放，
因此只讓 `.content-image` 對於底下 `img` 的設定無法擴及 `.lightbox-img`，並移除 `.lightbox-img` 的 `object-` 相關設定。