### PR TITLE
feat: RelatedListOverContent 根據 seciton 換顏色

### DIFF
--- a/src/components/article/RelatedListOverContent.vue
+++ b/src/components/article/RelatedListOverContent.vue
@@ -11,9 +11,9 @@
           class="related"
           @click="sendGaClickEvent('article', 'related news left')"
         >
-          <div class="related__arrow" />
-          <div class="related__txt">
-            <div class="related__category">{{ relatedCategory }}</div>
+          <div class="related__arrow" :style="{ backgroundColor: sectionColor }" />
+          <div class="related__txt" :style="{ outlineColor: sectionColor }">
+            <div class="related__category" :style="{ backgroundColor: sectionColor }">{{ relatedCategory }}</div>
             <div class="related__title">
               <p>{{ _get(articles[ 0 ], 'title', '') }}</p>
             </div>
@@ -24,13 +24,13 @@
           class="related"
           @click="sendGaClickEvent('article', 'related news right')"
         >
-          <div class="related__txt">
-            <div class="related__category">{{ relatedCategory }}</div>
+          <div class="related__txt" :style="{ outlineColor: sectionColor }">
+            <div class="related__category" :style="{ backgroundColor: sectionColor }">{{ relatedCategory }}</div>
             <div class="related__title">
               <p>{{ _get(articles[ 1 ], 'title', '') }}</p>
             </div>
           </div>
-          <div class="related__arrow" />
+          <div class="related__arrow" :style="{ backgroundColor: sectionColor }" />
         </a>
       </div>
     </div>
@@ -39,11 +39,25 @@
 
 <script>
 import { get as _get } from 'lodash'
+import { SECTION_MAP, DEFAULT_SECTION_BGCOLOR } from '../../constants'
 import { sendGaClickEvent } from '../../util/comm'
 
 export default {
   name: 'RelatedListOverContent',
-  props: ['articles', 'relatedCategory'],
+  props: {
+    sectionId: {
+      type: String,
+      required: true
+    },
+    articles: {
+      type: Array,
+      required: true
+    },
+    relatedCategory: {
+      type: String,
+      required: true
+    }
+  },
   data () {
     return {
       showContent: false,
@@ -56,6 +70,9 @@ export default {
   computed: {
     isLapW () {
       return this.ww >= 1200
+    },
+    sectionColor () {
+      return _get(SECTION_MAP, `${this.sectionId}.bgcolor`, DEFAULT_SECTION_BGCOLOR)
     }
   },
   mounted () {
@@ -126,7 +143,7 @@ export default {
       border-top-right-radius 4px
       border-bottom-right-radius 4px
     &__arrow
-      background-color #ae4182
+      // background-color #ae4182
       width 26px
       flex 0 0 auto
       position relative
@@ -158,7 +175,7 @@ export default {
     &__category
       display none
       color #fff
-      background-color #ae4182
+      // background-color #ae4182
       align-self flex-start
       padding 2px 7px
       flex 0 0 auto
@@ -180,7 +197,9 @@ export default {
         height calc(1em * 1.5 * 2)
     &:hover, :active
       & .related__txt
-        outline 2px solid #ae4182
+        // outline 2px solid #ae4182
+        outline-style solid
+        outline-width 2px
         outline-offset -2px
 .fade
   &-enter-active, &-leave-active

--- a/src/components/article/RelatedListOverContent.vue
+++ b/src/components/article/RelatedListOverContent.vue
@@ -143,7 +143,6 @@ export default {
       border-top-right-radius 4px
       border-bottom-right-radius 4px
     &__arrow
-      // background-color #ae4182
       width 26px
       flex 0 0 auto
       position relative
@@ -175,7 +174,6 @@ export default {
     &__category
       display none
       color #fff
-      // background-color #ae4182
       align-self flex-start
       padding 2px 7px
       flex 0 0 auto
@@ -197,7 +195,6 @@ export default {
         height calc(1em * 1.5 * 2)
     &:hover, :active
       & .related__txt
-        // outline 2px solid #ae4182
         outline-style solid
         outline-width 2px
         outline-offset -2px

--- a/src/constants/index.js
+++ b/src/constants/index.js
@@ -28,6 +28,8 @@ export const SECTION_MAP = {
   external: { sectionName: 'external', bgcolor: '#ee5a24' }
 }
 
+export const DEFAULT_SECTION_BGCOLOR = '#bcbcbc'
+
 export const OATH_PLAYLIST = {
   '5c4151124d981a0001477e0e': { order: 1, name: '鏡封面', categoryName: 'video_coverstory', id: '5c4151124d981a0001477e0e' },
   '5c41528dbd70380001962364': { order: 2, name: '鏡娛樂', categoryName: 'video_ent_headline', id: '5c41528dbd70380001962364' },

--- a/src/views/Article.vue
+++ b/src/views/Article.vue
@@ -24,6 +24,7 @@
 
       <RelatedListOverContent
         v-if="!isArticlePhotography"
+        :section-id="sectionId"
         :articles="relateds"
         :related-category="relatedCategory"
       />


### PR DESCRIPTION
**調整項目：**
由於取得 section id 的計算屬性 `sectionId` 可能會回傳 `'other'`（目前不知道為何要做此設計），
使 `RelatedListOverContent` 無法從 `SECTION_MAP` 取得顏色，
因此增加了一個常數 `DEFAULT_SECTION_BGCOLOR` 來作為沒取到顏色時的替代選項。