### PR TITLE
fix(RelatedListOverContent): 使當 articles 只有一篇文章時，右邊區塊會被隱藏

### DIFF
--- a/src/components/article/RelatedListOverContent.vue
+++ b/src/components/article/RelatedListOverContent.vue
@@ -22,6 +22,7 @@
         <a
           :href="`/story/${_get(articles[ 1 ], 'slug', '')}`"
           class="related"
+          :class="{ 'vidibility-h': !articles[ 1 ] }"
           @click="sendGaClickEvent('article', 'related news right')"
         >
           <div class="related__txt" :style="{ outlineColor: sectionColor }">
@@ -198,6 +199,8 @@ export default {
         outline-style solid
         outline-width 2px
         outline-offset -2px
+.vidibility-h
+  visibility hidden
 .fade
   &-enter-active, &-leave-active
     transition all 0.2s ease-in-out


### PR DESCRIPTION
不檢查左邊區塊是否有文章，是因為當左邊區塊沒有文章時，便代表這篇新聞沒有相關文章，
此時這個 component 便會透過 `showContent` 而被隱藏。